### PR TITLE
feat: allow blocking any URL prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ When not specified, the current directory is checked recursively.
 - `-i`, `--interactive`: Run in interactive mode. Ask for confirmation before writing each change.
 - `-e EXT`, `--ext EXT`: File extensions to check when recursively walking directories.
 - `-s PATH`, `--skip PATH`: Paths to skip when recursively walking directories.
-- `-b DOMAIN`, `--block DOMAIN`: Domains to never check for updates.
+- `-b URL`, `--block URL`: URL prefixes to never check for updates.
 - `--max-update RELEASE`: Try to find updates up to the specified release type.
 
 ## Example

--- a/__snapshots__/main.test.ts.snap
+++ b/__snapshots__/main.test.ts.snap
@@ -4264,3 +4264,61 @@ snapshot[`writes updates with blocked domains specified 1`] = `
   },
 }
 `;
+
+snapshot[`writes updates with blocked domains specified 2`] = `
+{
+  content: {
+    "help.md": [
+      "Check out [lib](https://libs.example.com/lib@1.0.0/mod.js).",
+    ],
+    "help.txt": [
+      "Check out https://libs.example.com/lib@1.0.0/mod.js.",
+    ],
+    "tasks.ini": [
+      'start="deno run https://mods.example.com/x/example@v1.2.3/mod.ts"',
+    ],
+    "tasks.json": [
+      '{ "start": "deno run https://mods.example.com/x/example@v1/mod.ts" }',
+    ],
+    "tasks.yml": [
+      "start: deno run https://mods.example.com/x/example@v2/mod.ts",
+    ],
+    node_modules: {
+      "foo.js": [
+        'import "https://libs.example.com/lib@1.0.0/mod.js";',
+      ],
+    },
+    src: {
+      "App.jsx": [
+        'import * as React from "https://libs.example.com/react@17.0.2";',
+      ],
+      "App.tsx": [
+        'import * as React from "https://libs.example.com/preact@10.0.0";',
+      ],
+      "bar.ts": [
+        'import("https://libs.example.com/lib@2.0.0/mod.js");',
+        'import("https://libs.example.com/lib@1.0.0/mod.js");',
+      ],
+      "foo.js": [
+        'import "https://libs.example.com/lib@1.0.0/mod.js";',
+        'import "https://libs.example.com/unknown@1.0.0/mod.js";',
+      ],
+    },
+    static: {
+      "page.html": [
+        '<script src="https://libs.example.com/jquery@3.5/dist/jquery.min.js"></script>',
+        '<link rel="stylesheet" href="https://libs.example.com/bootstrap@4.5/dist/bootstrap.min.css">',
+        '<img src="https://cdn.example.com/dist/img/logo.png" alt="Logo">',
+      ],
+      "style.css": [
+        '@import "https://libs.example.com/bootstrap@4/dist/bootstrap.min.css";',
+        "header { background-image: url('https://cdn.example.com/dist/img/logo.jpg'); }",
+      ],
+    },
+  },
+  errors: Set(0) {},
+  result: {
+    updates: Set(0) {},
+  },
+}
+`;

--- a/listUpdates.ts
+++ b/listUpdates.ts
@@ -18,7 +18,7 @@ const urlRegexp =
   /\bhttps?:\/\/[\w\d.-]+\/[\w\d!#%&*?@^<=>/[\]:.~+-]*[\w\d!#&*?@^=/[\]:~+-]/dgi;
 
 export interface ListFileUpdatesOptions extends CheckUpdateOptions {
-  blockDomains?: RegExp[] | undefined;
+  blockUrls?: RegExp[] | undefined;
   memoize?: boolean | undefined;
   onError?:
     | ((filePath: string, url: string | undefined, error: Error) => void)
@@ -101,12 +101,7 @@ export async function* listFileUpdates(
 
       if (!url.match(versionRegexp)) return;
 
-      try {
-        const domain = new URL(url).hostname;
-        if (options?.blockDomains?.some((re) => re.test(domain))) {
-          return;
-        }
-      } catch {
+      if (options?.blockUrls?.some((re) => url.match(re))) {
         return;
       }
 

--- a/main.test.ts
+++ b/main.test.ts
@@ -224,14 +224,28 @@ Deno.test("writes updates with skip paths specified", async (t) => {
 });
 
 Deno.test("writes updates with blocked domains specified", async (t) => {
-  const output = await testFixture([
-    "-w",
-    "--block",
-    "mods.example.com",
-  ], redirects);
-  assertEquals(
-    await testFixture(["-w", "-b", "mods.example.com"], redirects),
-    output,
-  );
-  await assertSnapshot(t, output);
+  {
+    const output = await testFixture([
+      "-w",
+      "--block",
+      "https://mods.example.com",
+    ], redirects);
+    assertEquals(
+      await testFixture(["-w", "-b", "https://mods.example.com"], redirects),
+      output,
+    );
+    // TODO: disallow protocol-less URLs in next major version
+    assertEquals(
+      await testFixture(["-w", "-b", "mods.example.com"], redirects),
+      output,
+    );
+    await assertSnapshot(t, output);
+  }
+  {
+    const output = await testFixture(
+      ["-w", "-b", "https://*.example.com"],
+      redirects,
+    );
+    await assertSnapshot(t, output);
+  }
 });


### PR DESCRIPTION
Block pattern can now match any URL prefix (including protocol and path) instead of just domain. Optional prefix `https://` is automatically added to every pattern for backwards compatibility.